### PR TITLE
Add frame-based navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Robotten har 8 minutter til at finde, samle og aflevere boldene i en udgangsåbn
 | `hatch2.py`       | Funktioner til boldskubber                                                   |
 | `vision.py`       | (Kommende) Billedgenkendelse og VIP-bold identifikation                      |
 | `navigation.py`   | (Kommende) Pathfinding og positionsstyring                                   |
+| `frame_navigator.py` | Dynamisk styring billede for billede |
 | `tests/`          | Testkode til hardware og mekanismer (fx test af motorer og sekvenser)        |
 
 ---
@@ -83,6 +84,13 @@ Robotten har 8 minutter til at finde, samle og aflevere boldene i en udgangsåbn
 from main import main
 main()
 ```
+### Naviger billede for billede
+```python
+from Movement.frame_navigator import FrameNavigator
+nav = FrameNavigator([(100, 200), (300, 400)])
+nav.run()
+```
+
 
 ### Brug hjælpefunktioner direkte
 ```python

--- a/src/Movement/frame_navigator.py
+++ b/src/Movement/frame_navigator.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+import cv2
+
+from track_robot import get_robot_pose
+from PathFinding.ArrowVector import ArrowVector
+from AutonomousClient import send_and_receive
+
+
+# --- helper ---------------------------------------------------------------
+
+def calculate_next_command(robot_pos: Tuple[int, int], heading_deg: float,
+                           target_pos: Tuple[int, int], *,
+                           angle_threshold: float = 10.0,
+                           capture_distance: float = 80.0,
+                           step_mm: float = 80.0) -> str:
+    """Return the next command for moving towards *target_pos*.
+
+    The command is one of:
+        - "turn_left_deg(... )\n"
+        - "turn_right_deg(... )\n"
+        - "drive_straight_mm(... )\n"
+        - "capture" when the robot should pick up the ball
+    """
+    vector = ArrowVector(robot_pos, target_pos)
+    distance = vector.get_size()
+    target_angle = vector.get_angle()
+
+    diff = (target_angle - heading_deg + 360) % 360
+    if diff > 180:
+        diff -= 360
+
+    if abs(diff) > angle_threshold:
+        if diff > 0:
+            return f"turn_right_deg({abs(int(diff))})\n"
+        return f"turn_left_deg({abs(int(diff))})\n"
+
+    if distance > capture_distance:
+        step = min(step_mm, distance - capture_distance)
+        return f"drive_straight_mm({int(step)})\n"
+
+    return "capture"
+
+
+# --- main navigation class -----------------------------------------------
+
+class FrameNavigator:
+    def __init__(self, balls: List[Tuple[int, int]], *,
+                 angle_threshold: float = 10.0,
+                 capture_distance: float = 80.0,
+                 step_mm: float = 80.0,
+                 video_src: int = 0):
+        self.balls = list(balls)
+        self.angle_threshold = angle_threshold
+        self.capture_distance = capture_distance
+        self.step_mm = step_mm
+        self.cap = cv2.VideoCapture(video_src)
+
+    def close(self) -> None:
+        if self.cap:
+            self.cap.release()
+            self.cap = None
+
+    def run(self) -> None:
+        idx = 0
+        while idx < len(self.balls) and self.cap.isOpened():
+            ret, frame = self.cap.read()
+            if not ret:
+                break
+            pose = get_robot_pose(frame)
+            if not pose:
+                continue
+            (cx, cy), heading = pose
+            cmd = calculate_next_command((cx, cy), heading, self.balls[idx],
+                                         angle_threshold=self.angle_threshold,
+                                         capture_distance=self.capture_distance,
+                                         step_mm=self.step_mm)
+            if cmd == "capture":
+                capture_seq = (
+                    "open_gate()\n"
+                    "drive_straight_mm(50)\n"
+                    "close_gate()\n"
+                )
+                send_and_receive(capture_seq)
+                idx += 1
+            else:
+                send_and_receive(cmd)
+        self.close()
+

--- a/src/tests/test_frame_navigator.py
+++ b/src/tests/test_frame_navigator.py
@@ -1,0 +1,19 @@
+import sys
+import sys
+sys.path.append("src")
+from Movement.frame_navigator import calculate_next_command
+
+
+def test_turn_needed():
+    cmd = calculate_next_command((0, 0), 0, (0, 100), angle_threshold=5)
+    assert cmd.startswith("turn_right_deg") or cmd.startswith("turn_left_deg")
+
+
+def test_drive_forward():
+    cmd = calculate_next_command((0, 0), 0, (100, 0), angle_threshold=5, capture_distance=10, step_mm=30)
+    assert cmd.startswith("drive_straight_mm")
+
+
+def test_capture_command():
+    cmd = calculate_next_command((0, 0), 0, (1, 0), capture_distance=5)
+    assert cmd == "capture"


### PR DESCRIPTION
## Summary
- implement `FrameNavigator` for image-by-image path correction
- add unit test for the command calculation logic
- document new script in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_6858131e5c6c832fb9a3643e43a33dbb